### PR TITLE
Install and enable php opcache too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update -y && \
     php-mbstring \
     php-soap \
     php-apcu \
+    php-opcache \
     php-ldap \
     php-imap \
     mysql-client \

--- a/rootfs/etc/php/7.0/mods-available/wordpress.ini
+++ b/rootfs/etc/php/7.0/mods-available/wordpress.ini
@@ -4,3 +4,9 @@ apc.enable_cli = 1
 
 upload_max_filesize = 20G
 post_max_size = 8M
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=4000
+opcache.revalidate_freq=60
+opcache.fast_shutdown=1
+opcache.enable_cli=1


### PR DESCRIPTION
apcu is purely for application specific caches, opcache will noticeable increase the performance of the running wordpress instance.